### PR TITLE
Add common.js tests for message preferences coverage

### DIFF
--- a/test/base.js
+++ b/test/base.js
@@ -703,6 +703,52 @@ describe('any', () => {
             ]);
         });
 
+        it('merges two objects (multi)', () => {
+
+            const a = Joi.number().multiple(2);
+            const b = Joi.number().multiple(5);
+
+            const ab = a.concat(b);
+
+            Helper.validate(a, [
+                [2, true],
+                [5, false,  {
+                    message: '"value" must be a multiple of 2',
+                    path: [],
+                    type: 'number.multiple',
+                    context: { value: 5, multiple: 2, label: 'value' }
+                }],
+                [10, true]
+            ]);
+
+            Helper.validate(b, [
+                [2, false,  {
+                    message: '"value" must be a multiple of 5',
+                    path: [],
+                    type: 'number.multiple',
+                    context: { value: 2, multiple: 5, label: 'value' }
+                }],
+                [5, true],
+                [10, true]
+            ]);
+
+            Helper.validate(ab, [
+                [2, false,  {
+                    message: '"value" must be a multiple of 5',
+                    path: [],
+                    type: 'number.multiple',
+                    context: { value: 2, multiple: 5, label: 'value' }
+                }],
+                [5, false, {
+                    message: '"value" must be a multiple of 2',
+                    path: [],
+                    type: 'number.multiple',
+                    context: { value: 5, multiple: 2, label: 'value' }
+                }],
+                [10, true]
+            ]);
+        });
+
         it('throws when schema key types do not match', () => {
 
             const a = Joi.object({ a: Joi.number() });

--- a/test/common.js
+++ b/test/common.js
@@ -4,6 +4,7 @@ const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 
 const Common = require('../lib/common');
+const Template = require('../lib/template');
 
 
 const internals = {};
@@ -20,6 +21,48 @@ describe('Common', () => {
         it('validates null', () => {
 
             expect(() => Common.assertOptions()).to.throw('Options must be of type object');
+        });
+    });
+
+    describe('preferences', () => {
+
+        it('uses the provided messages value', () => {
+
+            const { messages } = Common.preferences({}, { messages: 'custom value' });
+            expect(messages.source).to.equal('custom value');
+        });
+
+        it('uses the provided messages template value', () => {
+
+            const messageTemplate = new Template('custom template value');
+            const { messages } = Common.preferences({}, { messages: messageTemplate });
+            expect(messages.source).to.equal('custom template value');
+        });
+
+        it('uses the provided messages value by language', () => {
+
+            const messageByLanguage = { english: { 'number.min': 'custom message for number.min' } };
+            const defaultMessagesByLanguage = { english: { 'number.min': 'default message for number.min' } };
+            const { messages } = Common.preferences({ messages: defaultMessagesByLanguage }, { messages: messageByLanguage });
+            expect(messages.english['number.min'].source).to.equal('custom message for number.min');
+
+        });
+
+        it('throws with an invalid messages value', () => {
+
+            expect(() => Common.preferences({ messages: [] }, { messages: 'single string error' })).to.throw('Cannot set single message string');
+        });
+
+        it('throws with an invalid messages template value', () => {
+
+            const messageTemplate = new Template('custom template value');
+            expect(() => Common.preferences({ messages: [] }, { messages: messageTemplate })).to.throw('Cannot set single message template');
+        });
+
+        it('throws with invalid messages options', () => {
+
+            expect(() => Common.preferences({ messages: [] }, { messages: true })).to.throw('Invalid message options');
+            expect(() => Common.preferences({ messages: [] }, { messages: { code: true } })).to.throw('Invalid message for code');
         });
     });
 });

--- a/test/common.js
+++ b/test/common.js
@@ -3,6 +3,7 @@
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 
+const Joi = require('..');
 const Common = require('../lib/common');
 const Template = require('../lib/template');
 
@@ -63,6 +64,25 @@ describe('Common', () => {
 
             expect(() => Common.preferences({ messages: [] }, { messages: true })).to.throw('Invalid message options');
             expect(() => Common.preferences({ messages: [] }, { messages: { code: true } })).to.throw('Invalid message for code');
+        });
+    });
+
+    describe('validateArg', () => {
+
+        it('returns nothing if valid', () => {
+
+            const value = 1234;
+            const assert = Joi.number();
+
+            expect(Common.validateArg(value, null, { assert })).to.not.exist();
+        });
+
+        it('returns error message if invalid', () => {
+
+            const value = 1234.5;
+            const assert = Joi.number().integer();
+
+            expect(Common.validateArg(value, null, { assert })).to.equal('"value" must be an integer');
         });
     });
 });

--- a/test/modify.js
+++ b/test/modify.js
@@ -3,6 +3,9 @@
 const Code = require('@hapi/code');
 const Lab = require('@hapi/lab');
 const Joi = require('..');
+const Modify = require('../lib/modify');
+const Extend = require('../lib/extend');
+const Ref = require('../lib/ref');
 
 const Helper = require('./helper');
 
@@ -33,6 +36,211 @@ describe('Modify', () => {
 
             const schema = Joi.any().id('x');
             Helper.equal(schema.id('y'), Joi.any().id('y'));
+        });
+    });
+
+    describe('schema()', () => {
+
+        it('returns undefined when schema is not modified', () => {
+
+            const schema = Joi.string();
+
+            expect(Modify.schema(schema, { each: (x) => x })).to.not.exist();
+            expect(Modify.schema(schema, { each: () => undefined })).to.not.exist();
+        });
+
+        it('modifies schema with flags, terms, and rules', () => {
+
+            const schema1 = Joi.object().keys({
+                a: Joi.string(),
+                b: Joi.string()
+            })
+                .pattern(/c/, Joi.number());
+
+            const modified1 = Modify.schema(schema1, {
+                each: () => Joi.any()
+            });
+
+            Helper.validate(modified1, [
+                [{ a: null, b: null }, true],
+                [{ c: 'x' }, true]
+            ]);
+
+            const schema2 = Joi.object()
+                .assert(Joi.ref('.a'), Joi.valid(Joi.ref('b')).id('assertion'))
+                .pattern(/a|b|c/, Joi.number().min(3));
+
+            const modified2 = Modify.schema(schema2, {
+                each: (x) => {
+
+                    if (Ref.isRef(x)) {
+                        return Joi.ref('.b');
+                    }
+
+                    if (x._flags.id === 'assertion') {
+                        return Joi.valid(Joi.ref('c'));
+                    }
+
+                    return Joi.any();
+                }
+            });
+
+            Helper.validate(modified2, [
+                [{ a: 2, c: 3 }, true],
+                [{ b: 'x', c: 'x' }, true],
+                [{ b: 'x', c: 'y' }, false, {
+                    message: '"value" is invalid because it failed to pass the assertion test',
+                    path: [],
+                    type: 'object.assert',
+                    context: {
+                        label: 'value',
+                        message: undefined,
+                        subject: Joi.ref('.b'),
+                        value: {
+                            b: 'x',
+                            c: 'y'
+                        }
+                    }
+                }]
+            ]);
+
+            const schema3 = Joi.object({
+                a: Joi.string()
+            })
+                .unknown()
+                .assert('a', 'x');
+
+            const modified3 = Modify.schema(schema3, {
+                each: (x) => {
+
+                    return Ref.isRef(x) ? Joi.ref('.c') : Joi.any();
+                }
+            });
+
+            Helper.validate(modified3, [
+                [{ a: 'x' }, true],
+                [{ c: 'x' }, true]
+            ]);
+
+            const schema4 = Joi.object({
+                a: Joi.string()
+            })
+                .empty(Joi.string());
+
+            const modified4 = Modify.schema(schema4, {
+                each: (x) => x.min(2)
+            });
+
+            Helper.validate(modified4, [
+                [{ a: 'xx' }, true],
+                [{ a: 'x' }, false, {
+                    context: {
+                        encoding: undefined,
+                        key: 'a',
+                        label: 'a',
+                        limit: 2,
+                        value: 'x'
+                    },
+                    message: '"a" length must be at least 2 characters long',
+                    path: ['a'],
+                    type: 'string.min'
+                }],
+                ['y', false, {
+                    context: {
+                        label: 'value',
+                        type: 'object',
+                        value: 'y'
+                    },
+                    message: '"value" must be of type object',
+                    path: [],
+                    type: 'object.base'
+                }]
+            ]);
+
+            expect(modified4.validate('yy').value).to.not.exist();
+        });
+
+        it('changes multiple schemas in different sources', () => {
+
+            const schema = Extend.type(Joi.any(), {
+                coerce(value, helpers) {
+
+                    const swap = helpers.schema.$_getFlag('swap');
+                    if (swap &&
+                        swap.$_match(value, helpers.state.nest(swap), helpers.prefs)) {
+
+                        return { value: ['swapped'] };
+                    }
+                },
+                terms: {
+                    x: { init: [] }
+                },
+                rules: {
+                    swap: {
+                        method(schemaInput) {
+
+                            return this.$_setFlag('swap', this.$_compile(schemaInput));
+                        }
+                    },
+                    pattern: {
+                        method(schemaInput) {
+
+                            return this.$_addRule({ name: 'pattern', args: { schema: this.$_compile(schemaInput) } });
+                        },
+                        validate() { }
+                    },
+                    term: {
+                        method(schemaInput) {
+
+                            this.$_terms.x.push(schemaInput);
+                            return this;
+                        }
+                    }
+                }
+            })
+                .swap(Joi.number())
+                .empty(Joi.object())
+                .pattern(Joi.binary())
+                .term(Joi.number());
+
+            const each = (item) => item.min(10);
+
+            expect(schema.$_modify({ each, ref: false, schema: false })).to.equal(schema);
+
+            const modified = schema.$_modify({ each, ref: false });
+
+            // This test originates from joi and originally confirmed the
+            // schema using describe(), which is not supported by this module.
+
+            expect(modified).to.part.contain({
+                _flags: {
+                    empty: {
+                        type: 'object',
+                        _rules: [{ args: { limit: 10 }, name: 'min' }]
+                    },
+                    swap: {
+                        type: 'number',
+                        _rules: [{ args: { limit: 10 }, name: 'min' }]
+                    }
+                },
+                _rules: [{
+                    name: 'pattern',
+                    args: {
+                        schema: {
+                            type: 'binary',
+                            _rules: [{ args: { limit: 10 }, name: 'min' }]
+                        }
+                    }
+                }],
+                _terms: {
+                    x: [
+                        {
+                            type: 'number',
+                            _rules: [{ args: { limit: 10 }, name: 'min' }]
+                        }
+                    ]
+                }
+            });
         });
     });
 });

--- a/test/types/alternatives.js
+++ b/test/types/alternatives.js
@@ -180,6 +180,30 @@ describe('alternatives', () => {
             ]);
         });
 
+        it('respects optional presence', () => {
+
+            const schema = Joi.object().keys({
+                a: Joi.boolean(),
+                b: Joi.alternatives().conditional('a', {
+                    is: true,
+                    then: Joi.object(),
+                    otherwise: Joi.string().empty('').allow(null)
+                })
+            });
+
+            Helper.validate(schema, [
+                [{ a: true }, true],
+                [{ a: false }, true],
+                [{ a: true, b: {} }, true],
+                [{ a: false, b: 1 }, false, {
+                    message: '"b" must be a string',
+                    path: ['b'],
+                    type: 'string.base',
+                    context: { value: 1, key: 'b', label: 'b' }
+                }]
+            ]);
+        });
+
         describe('with ref', () => {
 
             it('validates conditional alternatives', () => {

--- a/test/types/any.js
+++ b/test/types/any.js
@@ -2,6 +2,7 @@
 
 const Code = require('@hapi/code');
 const Joi = require('../..');
+const Template = require('../../lib/template');
 const Lab = require('@hapi/lab');
 
 const Helper = require('../helper');
@@ -84,6 +85,14 @@ describe('any', () => {
             };
 
             Helper.equal(Joi.string().valid('x').messages(messages), Joi.string().valid('x').prefs({ messages }));
+        });
+
+        it('uses the provided messages template value', () => {
+
+            const messageTemplate = new Template('custom property name');
+            const schema = Joi.string().valid('x').messages({ root: messageTemplate });
+            const { error } = schema.validate('y');
+            expect(error.message).to.equal('"custom property name" must be one of [x]');
         });
     });
 


### PR DESCRIPTION
100% coverage on `lib/messages.js`, slight improvements in `/lib/errors.js` and `/lib/template.js` as a bonus :).

The test added to the `test/types/any.js` is technically redundant, but I thought was a good addition from a "tests as documentation" perspective.