### PR TITLE
Fix string coverage

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -38,7 +38,6 @@ const internals = {
     },
     guidSeparators: new Set([undefined, true, false, '-', ':']),
 
-    cidrPresences: ['required', 'optional', 'forbidden'],
     normalizationForms: ['NFC', 'NFD', 'NFKC', 'NFKD'],
 
     domainControlRx: /[\x00-\x20@\:\/]/,                                                // Control + space + separators

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -656,72 +656,26 @@ internals.rfc3986 = function () {
 };
 
 
-internals.ipRegex = function (options = {}) {
+internals.ipRegex = (function () {
 
-    // CIDR
-
-    Assert(options.cidr === undefined || typeof options.cidr === 'string', 'options.cidr must be a string');
-    const cidr = options.cidr ? options.cidr.toLowerCase() : 'optional';
-    Assert(['required', 'optional', 'forbidden'].includes(cidr), 'options.cidr must be one of required, optional, forbidden');
-
-    // Versions
-
-    Assert(options.version === undefined || typeof options.version === 'string' || Array.isArray(options.version), 'options.version must be a string or an array of string');
-    let versions = options.version || ['ipv4', 'ipv6', 'ipvfuture'];
-    if (!Array.isArray(versions)) {
-        versions = [versions];
-    }
-
-    Assert(versions.length >= 1, 'options.version must have at least 1 version specified');
-
-    for (let i = 0; i < versions.length; ++i) {
-        Assert(typeof versions[i] === 'string', 'options.version must only contain strings');
-        versions[i] = versions[i].toLowerCase();
-        Assert(['ipv4', 'ipv6', 'ipvfuture'].includes(versions[i]), 'options.version contains unknown version ' + versions[i] + ' - must be one of ipv4, ipv6, ipvfuture');
-    }
-
-    versions = Array.from(new Set(versions));
+    const versions = ['ipv4', 'ipv6', 'ipvfuture'];
 
     // Regex
 
     const rfc3986 = internals.rfc3986();
     const parts = versions.map((version) => {
 
-        // Forbidden
-
-        if (cidr === 'forbidden') {
-            return rfc3986[version];
-        }
-
-        // Required
-
         const cidrpart = `\\/${version === 'ipv4' ? rfc3986.v4Cidr : rfc3986.v6Cidr}`;
-
-        if (cidr === 'required') {
-            return `${rfc3986[version]}${cidrpart}`;
-        }
-
-        // Optional
 
         return `${rfc3986[version]}(?:${cidrpart})?`;
     });
 
     const raw = `(?:${parts.join('|')})`;
     return new RegExp(`^${raw}$`);
-};
-
-internals.ipRegex = internals.ipRegex();
+})();
 
 
 internals.isDomainValid = function (domain) {
-
-    if (typeof domain !== 'string') {
-        return false;
-    }
-
-    if (!domain) {
-        return false;
-    }
 
     if (domain.length > 256) {
         return false;

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -3333,6 +3333,30 @@ describe('string', () => {
                     type: 'string.hostname',
                     context: { value: 'host:name', label: 'value' }
                 }],
+                ['a..com', false, {
+                    message: '"value" must be a valid hostname',
+                    path: [],
+                    type: 'string.hostname',
+                    context: { value: 'a..com', label: 'value' }
+                }],
+                ['+.com', false, {
+                    message: '"value" must be a valid hostname',
+                    path: [],
+                    type: 'string.hostname',
+                    context: { value: '+.com', label: 'value' }
+                }],
+                ['abcdefghijklmnopqrstuvxyzabcdefghijklmnopqrstuvxyzabcdefghijklmn.com', false, {
+                    message: '"value" must be a valid hostname',
+                    path: [],
+                    type: 'string.hostname',
+                    context: { value: 'abcdefghijklmnopqrstuvxyzabcdefghijklmnopqrstuvxyzabcdefghijklmn.com', label: 'value' }
+                }],
+                ['%C8', false, {
+                    message: '"value" must be a valid hostname',
+                    path: [],
+                    type: 'string.hostname',
+                    context: { value: '%C8', label: 'value' }
+                }],
                 ['-', false, {
                     message: '"value" must be a valid hostname',
                     path: [],
@@ -3346,7 +3370,16 @@ describe('string', () => {
                     type: 'string.hostname',
                     context: { value: '01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789', label: 'value' }
                 }],
+                ['1.2.3.4', true],
+                ['1.2.3.4/16', true],
+                ['1.2.300.4', false, {
+                    message: '"value" must be a valid hostname',
+                    path: [],
+                    type: 'string.hostname',
+                    context: { value: '1.2.300.4', label: 'value' }
+                }],
                 ['::1', true],
+                ['::1/32', true],
                 ['0:0:0:0:0:0:0:1', true],
                 ['0:?:0:0:0:0:0:1', false, {
                     message: '"value" must be a valid hostname',


### PR DESCRIPTION
* Removed unused `options` from `internals.ipRegex()`
* Removed non-empty string checks from `internals.isDomainValid()` since it is only called from a string validator.
* Added more checks.

For #1.