### PR TITLE
Complete initial test coverage of base, ref, and compile modules

### DIFF
--- a/lib/ref.js
+++ b/lib/ref.js
@@ -6,9 +6,6 @@ const Reach = require('@hapi/hoek/lib/reach');
 
 const Common = require('./common');
 
-let Template;
-
-
 const internals = {
     symbol: Symbol('ref'),      // Used to internally identify references (shared with other joi versions)
     defaults: {
@@ -325,14 +322,6 @@ exports.Manager = class {
             source.ancestor - target >= 0) {
 
             this.refs.push({ ancestor: source.ancestor - target, root: source.root });
-        }
-
-        // Template
-
-        Template = Template || require('./template');
-
-        if (Template.isTemplate(source)) {
-            this.register(source.refs(), target);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@hapi/lab": "22.x.x"
   },
   "scripts": {
-    "test": "lab -t 97 -a @hapi/code -L",
+    "test": "lab -t 100 -a @hapi/code -L",
     "test-cov-html": "lab -r html -o coverage.html -a @hapi/code"
   },
   "license": "BSD-3-Clause"

--- a/test/ref.js
+++ b/test/ref.js
@@ -1136,5 +1136,16 @@ describe('ref', () => {
 
             expect(Joi.ref('a+b+c', { separator: '+' }).root).to.equal('a');
         });
+
+        it('respects custom local prefix', () => {
+
+            expect(Joi.ref('+a.b.c', { prefix: { local: '+' } })).to.contain({
+                type: 'local',
+                key: 'a.b.c',
+                root: 'a',
+                path: ['a', 'b', 'c'],
+                separator: '.'
+            });
+        });
     });
 });


### PR DESCRIPTION
This brings coverage of lib/base.js, lib/ref.js, and lib/compile.js up to 100%.  The CI is failing because I also flipped the coverage percentage back up to 100%.  The only code I changed within validate was removing vestigial support for template-style refs, i.e. what used to be usage of `Joi.expression()`/`Joi.x()` with references (`Joi.expression()` no longer exists).