### PR TITLE
Loosen restrictions on hostname TLDs regarding numeric digits

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -701,7 +701,7 @@ internals.isDomainValid = function (domain) {
             return false;
         }
 
-        // Here's we're following RFC 1035 and 1123, plus 3696's clarification
+        // Here we're following RFC 1035 and 1123, plus 3696's clarification
         // that TLDs (the final segment) may contain numbers but not be all-numeric.
         // Docker containers, for example, are assigned hostnames which are hex
         // strings (no dots) that may start with a numeric digit.

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -42,7 +42,7 @@ const internals = {
 
     domainControlRx: /[\x00-\x20@\:\/]/,                                                // Control + space + separators
     domainSegmentRx: /^[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?$/,
-    tldSegmentAdditionalRx: /[^0-9]/                                                    // Domain segment which is additionally not all-numeric
+    finalSegmentAdditionalRx: /[^0-9]/                                                    // Domain segment which is additionally not all-numeric
 };
 
 
@@ -702,7 +702,7 @@ internals.isDomainValid = function (domain) {
         }
 
         // Here we're following RFC 1035 and 1123, plus 3696's clarification
-        // that TLDs (the final segment) may contain numbers but not be all-numeric.
+        // that the final segment may contain numbers but not be all-numeric.
         // Docker containers, for example, are assigned hostnames which are hex
         // strings (no dots) that may start with a numeric digit.
 
@@ -710,9 +710,9 @@ internals.isDomainValid = function (domain) {
             return false;
         }
 
-        const isTld = i === segments.length - 1;
+        const isFinalSegment = i === segments.length - 1;
 
-        if (isTld && !internals.tldSegmentAdditionalRx.test(segment)) {
+        if (isFinalSegment && !internals.finalSegmentAdditionalRx.test(segment)) {
             return false;
         }
     }

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -42,7 +42,7 @@ const internals = {
 
     domainControlRx: /[\x00-\x20@\:\/]/,                                                // Control + space + separators
     domainSegmentRx: /^[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?$/,
-    finalSegmentAdditionalRx: /[^0-9]/                                                    // Domain segment which is additionally not all-numeric
+    finalSegmentAdditionalRx: /[^0-9]/                                                  // Domain segment which is additionally not all-numeric
 };
 
 

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -41,8 +41,8 @@ const internals = {
     normalizationForms: ['NFC', 'NFD', 'NFKC', 'NFKD'],
 
     domainControlRx: /[\x00-\x20@\:\/]/,                                                // Control + space + separators
-    tldSegmentRx: /^[a-zA-Z](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?$/,
-    domainSegmentRx: /^[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?$/
+    domainSegmentRx: /^[a-zA-Z0-9](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?$/,
+    tldSegmentAdditionalRx: /[^0-9]/                                                    // Domain segment which is additionally not all-numeric
 };
 
 
@@ -701,15 +701,19 @@ internals.isDomainValid = function (domain) {
             return false;
         }
 
-        if (i < segments.length - 1) {
-            if (!internals.domainSegmentRx.test(segment)) {
-                return false;
-            }
+        // Here's we're following RFC 1035 and 1123, plus 3696's clarification
+        // that TLDs (the final segment) may contain numbers but not be all-numeric.
+        // Docker containers, for example, are assigned hostnames which are hex
+        // strings (no dots) that may start with a numeric digit.
+
+        if (!internals.domainSegmentRx.test(segment)) {
+            return false;
         }
-        else {
-            if (!internals.tldSegmentRx.test(segment)) {
-                return false;
-            }
+
+        const isTld = i === segments.length - 1;
+
+        if (isTld && !internals.tldSegmentAdditionalRx.test(segment)) {
+            return false;
         }
     }
 

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -3326,7 +3326,9 @@ describe('string', () => {
                 ['www.example.com', true],
                 ['domain.local', true],
                 ['3domain.local', true],
+                ['domain.3local', true],
                 ['hostname', true],
+                ['3hostname', true],
                 ['host:name', false, {
                     message: '"value" must be a valid hostname',
                     path: [],


### PR DESCRIPTION
Fixes #18.  From our conversation there:
> There are protections related to the TLD's validation primarily in order to make it possible to distinguish an IP versus a domain. I believe a sound interpretation is to relax the TLD validation from requiring it to start with an alphabetic character to ensuring that it is not _all-numeric_. This is supported by [RFC 3696 section 2](https://tools.ietf.org/html/rfc3696#section-2)'s clarification to RFC 1123. See also https://serverfault.com/a/638270. I believe docker [is careful](https://github.com/docker/docker-ce/blob/6c81bbd59d78f35499d47a5832656b727e9925a0/components/engine/pkg/stringid/stringid.go#L47-L49) not to create all-numeric hostnames.

Previously TLDs were validated by requiring that the first character not be a numeric digit.  This PR relaxes that requirement to just ensure it contains _any_ character which is not a numeric digit, which seems to me like a more up-to-date interpretation of specs and will give Docker users less trouble.  It is also more in-line with versions of joi prior to v17.