### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v2
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
 Copyright (c) 2012-2014, Walmart.
 All rights reserved.
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -191,8 +191,8 @@ internals.Base = class {
         if (!['any', 'link'].includes(obj.type)) {
             const conditions = when.is ? [when] : when.switch;
             for (const item of conditions) {
-                Assert(!item.then || item.then.type === 'any' || item.then.type === obj.type, 'Cannot combine', obj.type, 'with', item.then && item.then.type);
-                Assert(!item.otherwise || item.otherwise.type === 'any' || item.otherwise.type === obj.type, 'Cannot combine', obj.type, 'with', item.otherwise && item.otherwise.type);
+                Assert(!item.then || item.then.type === 'any' || item.then.type === obj.type, 'Cannot combine', obj.type, 'with', item.then?.type);
+                Assert(!item.otherwise || item.otherwise.type === 'any' || item.otherwise.type === obj.type, 'Cannot combine', obj.type, 'with', item.otherwise?.type);
 
             }
         }
@@ -443,7 +443,7 @@ internals.Base = class {
 
         const each = (item, { source, name, path, key }) => {
 
-            const family = this._definition[source][name] && this._definition[source][name].register;
+            const family = this._definition[source][name]?.register;
             if (family !== false) {
                 this.$_mutateRegister(item, { family, key });
             }
@@ -526,8 +526,8 @@ internals.Base = class {
 
         target._ids = this._ids.clone();
         target._preferences = this._preferences;
-        target._valids = this._valids && this._valids.clone();
-        target._invalids = this._invalids && this._invalids.clone();
+        target._valids = this._valids?.clone();
+        target._invalids = this._invalids?.clone();
         target._rules = this._rules.slice();
         target._singleRules = Clone(this._singleRules, { shallow: true });
         target._refs = this._refs.clone();

--- a/lib/template.js
+++ b/lib/template.js
@@ -116,7 +116,7 @@ module.exports = exports = internals.Template = class {
             else {
                 const rendered = part.ref.resolve(value, state, prefs, local, options);
                 const string = internals.stringify(rendered, prefs, options.errors);
-                const result = part.raw || (options.errors && options.errors.escapeHtml) === false ? string : EscapeHtml(string);
+                const result = (part.raw || options.errors?.escapeHtml === false) ? string : EscapeHtml(string);
                 parts.push(internals.wrap(result, part.wrapped && prefs.errors.wrap.label));
             }
         }

--- a/lib/types/boolean.js
+++ b/lib/types/boolean.js
@@ -48,8 +48,8 @@ module.exports = Any._extend({
         }
 
         if (typeof value !== 'boolean') {
-            value = schema.$_terms.truthy && schema.$_terms.truthy.has(value, null, null, !schema._flags.sensitive) ||
-                (schema.$_terms.falsy && schema.$_terms.falsy.has(value, null, null, !schema._flags.sensitive) ? false : value);
+            value = schema.$_terms.truthy?.has(value, null, null, !schema._flags.sensitive) ||
+                (schema.$_terms.falsy?.has(value, null, null, !schema._flags.sensitive) ? false : value);
         }
 
         return { value };

--- a/lib/types/link.js
+++ b/lib/types/link.js
@@ -145,7 +145,7 @@ internals.perspective = function (ref, state) {
         return { perspective: state.schemas[state.schemas.length - 1].schema, path: ref.path };
     }
 
-    return { perspective: state.schemas[ref.ancestor] && state.schemas[ref.ancestor].schema, path: ref.path };
+    return { perspective: state.schemas[ref.ancestor]?.schema, path: ref.path };
 };
 
 

--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -392,7 +392,7 @@ module.exports = Any._extend({
             },
             validate(value, helpers, { limit, encoding }, { name, operator, args }) {
 
-                const length = encoding ? Buffer && Buffer.byteLength(value, encoding) : value.length;      // $lab:coverage:ignore$
+                const length = encoding ? Buffer.byteLength(value, encoding) : value.length;
                 if (Common.compare(length, limit, operator)) {
                     return value;
                 }
@@ -602,7 +602,7 @@ internals.isoDate = function (value) {
 
 internals.length = function (schema, name, limit, operator, encoding) {
 
-    Assert(!encoding || Buffer && Buffer.isEncoding(encoding), 'Invalid encoding:', encoding);      // $lab:coverage:ignore$
+    Assert(!encoding || Buffer.isEncoding(encoding), 'Invalid encoding:', encoding);
 
     return schema.$_addRule({ name, method: 'length', args: { limit, encoding }, operator });
 };

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "^9.0.0",
-    "@hapi/topo": "^5.0.0"
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/topo": "^6.0.0"
   },
   "devDependencies": {
-    "@hapi/bourne": "2.x.x",
-    "@hapi/code": "8.x.x",
+    "@hapi/bourne": "^3.0.0",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "25.0.0-beta.1"
   },
   "scripts": {
     "test": "lab -t 100 -a @hapi/code -L",

--- a/test/errors.js
+++ b/test/errors.js
@@ -39,7 +39,7 @@ describe('errors', () => {
         const err = Joi.valid('foo').validate('bar', { errors: { stack: true } }).error;
         expect(err).to.be.an.error();
         expect(err.isJoi).to.be.true();
-        expect(err.stack).to.contain('at Object.exports.process');
+        expect(err.stack).to.match(/at (?:Object\.)?exports\.process/); // As of node v18 "Object." is omitted
     });
 
     it('supports custom errors when validating types', () => {

--- a/test/helper.js
+++ b/test/helper.js
@@ -75,8 +75,8 @@ exports.validate = function (schema, prefs, tests) {
                 continue;
             }
 
-            if (schema._preferences && schema._preferences.abortEarly === false ||
-                prefs && prefs.abortEarly === false) {
+            if (schema._preferences?.abortEarly === false ||
+                prefs?.abortEarly === false) {
 
                 expect(error.message).to.equal(expected.message);
                 expect(error.details).to.equal(expected.details);


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of hoek, bourne, topo, lab, and code.

If this looks good, this will go out as validate v2.